### PR TITLE
Fix ffmpeg audio map

### DIFF
--- a/mpv/scripts/mpv2anki/modules/audio.lua
+++ b/mpv/scripts/mpv2anki/modules/audio.lua
@@ -79,6 +79,18 @@ function audio.create_audio_file(filename)
     local padding_end = 0.2                 -- Add padding at end
     local buffered_duration = duration + padding_start + padding_end
 
+    -- Get the current audio track (respects user's audio track selection)
+    local aid = mp.get_property("aid")
+    local audio_map = "0:a:0"  -- Default to first audio stream
+    
+    if aid and aid ~= "no" and aid ~= "" then
+        -- Use the currently selected audio track
+        audio_map = "0:" .. aid
+        msg.info("Using selected audio track: " .. aid)
+    else
+        msg.info("Using default audio track (first available)")
+    end
+
     -- Prepare FFmpeg command arguments
     local args = {
         ffmpeg_path,
@@ -86,7 +98,7 @@ function audio.create_audio_file(filename)
         "-i", input_file,       -- Input file
         "-ss", string.format("%.3f", sub_start - padding_start),  -- Start time with padding
         "-t", string.format("%.3f", buffered_duration),           -- Duration to extract
-        "-map", "0:a",          -- Select audio stream
+        "-map", audio_map,      -- Select the appropriate audio stream
         "-c:a", "libmp3lame",   -- Use MP3 codec
         "-q:a", "2",            -- Set audio quality (2 is high quality, range is 0-9)
         output_path


### PR DESCRIPTION
Hi 👋 
Stumbled upon this project by chance since I want to do some sentence mining to learn French.

## Description
Fixes an ffmpeg error if the video file has multiple audio streams.
Instead of running `ffmpeg.exe ... -map 0:a`, select the audio track used in mpv. For example `ffmpeg.exe ... -map 0:a:0`

- I'm on Windows and using ffmpeg from chocolatey: https://community.chocolatey.org/packages/ffmpeg.
- https://mpv.io/manual/master/#lua-scripting-mp-get-property(name-[,def])
- https://mpv.io/manual/master/#options-aid

<details><summary>Detailed error message</summary>

```
C:\\ProgramData\\chocolatey\\lib\\mpvio.install\\tools\\ffmpeg.exe -y -i D:\Videos\Asterix.et.Obelix.Le.Combat.des.Chefs.S01.FRENCH\Asterix.et.Obelix.Le.Combat.des.Chefs.S01E01.FRENCH.mkv -ss 59.816 -t 3.675 -map 0:a -c:a libmp3lame -q:a 2 "C:\Windows\Temp\mpv2anki-test.mp3"
ffmpeg version 8.0-essentials_build-www.gyan.dev Copyright (c) 2000-2025 the FFmpeg developers
  built with gcc 15.2.0 (Rev8, Built by MSYS2 project)
  configuration: --enable-gpl --enable-version3 --enable-static --disable-w32threads --disable-autodetect --enable-fontconfig --enable-iconv --enable-gnutls --enable-libxml2 --enable-gmp --enable-bzlib --enable-lzma --enable-zlib --enable-libsrt --enable-libssh --enable-libzmq --enable-avisynth --enable-sdl2 --enable-libwebp --enable-libx264 --enable-libx265 --enable-libxvid --enable-libaom --enable-libopenjpeg --enable-libvpx --enable-mediafoundation --enable-libass --enable-libfreetype --enable-libfribidi --enable-libharfbuzz --enable-libvidstab --enable-libvmaf --enable-libzimg --enable-amf --enable-cuda-llvm --enable-cuvid --enable-dxva2 --enable-d3d11va --enable-d3d12va --enable-ffnvcodec --enable-libvpl --enable-nvdec --enable-nvenc --enable-vaapi --enable-openal --enable-libgme --enable-libopenmpt --enable-libopencore-amrwb --enable-libmp3lame --enable-libtheora --enable-libvo-amrwbenc --enable-libgsm --enable-libopencore-amrnb --enable-libopus --enable-libspeex --enable-libvorbis --enable-librubberband
  libavutil      60.  8.100 / 60.  8.100
  libavcodec     62. 11.100 / 62. 11.100
  libavformat    62.  3.100 / 62.  3.100
  libavdevice    62.  1.100 / 62.  1.100
  libavfilter    11.  4.100 / 11.  4.100
  libswscale      9.  1.100 /  9.  1.100
  libswresample   6.  1.100 /  6.  1.100
Input #0, matroska,webm, from 'D:\Videos\Asterix.et.Obelix.Le.Combat.des.Chefs.S01.FRENCH\Asterix.et.Obelix.Le.Combat.des.Chefs.S01E01.FRENCH.mkv':
  Metadata:
    title           : Astérix & Obélix : Le Combat des Chefs - S01E01 - Épisode I
    encoder         : libebml v1.4.5 + libmatroska v1.7.1
    creation_time   : 2025-04-30T07:40:49.000000Z
  Duration: 00:35:28.00, start: 0.000000, bitrate: 3977 kb/s
  Chapters:
    Chapter #0:0: start 0.000000, end 1546.450000
      Metadata:
        title           : Part 01
    Chapter #0:1: start 1546.450000, end 2128.000000
      Metadata:
        title           : Credits
  Stream #0:0: Video: hevc (Main 10), yuv420p10le(tv, bt2020nc/bt2020/smpte2084), 1920x1080 [SAR 1:1 DAR 16:9], 24 fps, 24 tbr, 1k tbn (default)
    Metadata:
      BPS             : 2566904
      DURATION        : 00:35:28.000000000
      NUMBER_OF_FRAMES: 51072
      NUMBER_OF_BYTES : 682796516
      _STATISTICS_WRITING_APP: mkvmerge v92.0 ('Everglow') 64-bit
      _STATISTICS_WRITING_DATE_UTC: 2025-04-30 07:40:49
      _STATISTICS_TAGS: BPS DURATION NUMBER_OF_FRAMES NUMBER_OF_BYTES
    Side data:
      DOVI configuration record: version: 1.0, profile: 8, level: 3, rpu flag: 1, el flag: 0, bl flag: 1, compatibility id: 1, compression: 0
  Stream #0:1(fre): Audio: eac3 (Dolby Digital Plus + Dolby Atmos), 48000 Hz, 5.1(side), fltp, 768 kb/s (default) (original)
    Metadata:
      BPS             : 768000
      DURATION        : 00:35:27.968000000
      NUMBER_OF_FRAMES: 66499
      NUMBER_OF_BYTES : 204284928
      _STATISTICS_WRITING_APP: mkvmerge v92.0 ('Everglow') 64-bit
      _STATISTICS_WRITING_DATE_UTC: 2025-04-30 07:40:49
      _STATISTICS_TAGS: BPS DURATION NUMBER_OF_FRAMES NUMBER_OF_BYTES
  Stream #0:2(fre): Audio: eac3, 48000 Hz, 5.1(side), fltp, 640 kb/s (original) (visual impaired)
    Metadata:
      title           : AD
      BPS             : 640000
      DURATION        : 00:35:27.968000000
      NUMBER_OF_FRAMES: 66499
      NUMBER_OF_BYTES : 170237440
      _STATISTICS_WRITING_APP: mkvmerge v92.0 ('Everglow') 64-bit
      _STATISTICS_WRITING_DATE_UTC: 2025-04-30 07:40:49
      _STATISTICS_TAGS: BPS DURATION NUMBER_OF_FRAMES NUMBER_OF_BYTES
  Stream #0:3(fre): Subtitle: subrip (srt) (original) (hearing impaired)
    Metadata:
      title           : SDH
      BPS             : 72
      DURATION        : 00:30:45.458000000
      NUMBER_OF_FRAMES: 606
      NUMBER_OF_BYTES : 16713
      _STATISTICS_WRITING_APP: mkvmerge v92.0 ('Everglow') 64-bit
      _STATISTICS_WRITING_DATE_UTC: 2025-04-30 07:40:49
      _STATISTICS_TAGS: BPS DURATION NUMBER_OF_FRAMES NUMBER_OF_BYTES
Stream mapping:
  Stream #0:1 -> #0:0 (eac3 (native) -> mp3 (libmp3lame))
  Stream #0:2 -> #0:1 (eac3 (native) -> mp3 (libmp3lame))
Press [q] to stop, [?] for help
[mp3 @ 00000282f44855c0] Invalid audio stream. Exactly one MP3 audio stream is required.
[out#0/mp3 @ 00000282f2c64640] Could not write header (incorrect codec parameters ?): Invalid argument
[af#0:1 @ 00000282f2c8a300] Error sending frames to consumers: Invalid argument
[af#0:1 @ 00000282f2c8a300] Task finished with error code: -22 (Invalid argument)
[af#0:1 @ 00000282f2c8a300] Terminating thread with return code -22 (Invalid argument)
[out#0/mp3 @ 00000282f2c64640] Nothing was written into output file, because at least one of its streams received no packets.
size=       0KiB time=N/A bitrate=N/A speed=N/A elapsed=0:00:00.10
Conversion failed!
```

</details> 

## Related Issue

## Testing
Only tested manually by modifying the script and trying again.

## Screenshots (if appropriate)