### PR TITLE
Allow user to pick up their preferred screenshot option

### DIFF
--- a/mpv/script-opts/mpv2anki.conf
+++ b/mpv/script-opts/mpv2anki.conf
@@ -35,6 +35,12 @@ field_screenshot=Screenshot
 # field_subtitle1_extra=SentencePinyin
 # is_sentence_card=x
 
+
+# Screenshot type (no subtitles ("video") or with subtitles ("subtitles")
+# "video" by default, uncomment/comment line for the preferred option
+screenshot_to_file=video
+#screenshot_to_file=subtitles
+
 # Tags
 tags=sentence-mining
 

--- a/mpv/scripts/mpv2anki/config.lua
+++ b/mpv/scripts/mpv2anki/config.lua
@@ -108,6 +108,7 @@ local function get_config()
             },
             TAGS = parse_tags(user_config.tags or 'mpv,sentence-mining')
         },
+        SCREENSHOT_TYPE = user_config.screenshot_to_file or 'video',
         MEDIA = {
             FORMAT_IMAGE = user_config.format_image or 'jpg',
             FORMAT_AUDIO = user_config.format_audio or 'mp3',

--- a/mpv/scripts/mpv2anki/modules/screenshot.lua
+++ b/mpv/scripts/mpv2anki/modules/screenshot.lua
@@ -39,10 +39,16 @@ end
 function screenshot.create_screenshot(filename)
     local full_path = config.ANKI.MEDIA_PATH .. filename
 
+    local options = {"subtitles", "video"}
+    local user_option = config.SCREENSHOT_TYPE
+    if user_option ~= options[1] and user_option ~= options[2] then
+        user_option = "video"
+    end
+
     -- https://mpv.io/manual/master/#command-interface-screenshot-to-file
     local res = mp.commandv("screenshot-to-file",
-            full_path,
-            "video"  -- Only capture video, no subtitles (text)
+            full_path,  -- Filename
+            user_option
     )
 
     if not res then


### PR DESCRIPTION
## Description
Allow user to pick their preferred screenshot option (subtitles on screenshot, no subtitles)

## Related Issue
Fixes #9 

## Screenshots (if appropriate)

(example with "subtitles" option)
<img width="797" height="601" alt="Screenshot 2025-10-26 at 5 10 14 PM" src="https://github.com/user-attachments/assets/421ebfe4-8e21-493b-a263-f37b597424b1" />

